### PR TITLE
Create UNO-based AI spreadsheet prototype

### DIFF
--- a/AiCalc.sln
+++ b/AiCalc.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiCalc", "src/AiCalc/AiCalc.csproj", "{BBD6EEA1-24F8-4EF0-B5BA-43C0DB5C1A19}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{BBD6EEA1-24F8-4EF0-B5BA-43C0DB5C1A19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{BBD6EEA1-24F8-4EF0-B5BA-43C0DB5C1A19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{BBD6EEA1-24F8-4EF0-B5BA-43C0DB5C1A19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{BBD6EEA1-24F8-4EF0-B5BA-43C0DB5C1A19}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
-# aicalc
-AI based spreadsheet
+# AiCalc Studio
+
+AiCalc Studio is a concept UNO Platform application that delivers an AI-native spreadsheet experience. Each cell can host rich content such as directories, media, documents, links, or traditional scalar values while orchestrating AI workflows alongside classic spreadsheet logic.
+
+## Highlights
+
+- **Cross-platform UNO UI** targeting Windows, WebAssembly, and mobile platforms.
+- **Rich cell types** with visual glyphs that describe the current payload (text, images, video, directories, scripts, and more).
+- **AI function catalog** with starter functions for text-to-image, image captioning, directory introspection, and familiar numeric or string utilities.
+- **Workbook automation** that supports manual execution, auto-run on open, or dependency-triggered evaluation.
+- **Integrated inspector** to tweak values, formulas, automation mode, and notes while previewing output instantly.
+- **Connection settings** for registering local runtimes, Ollama, Azure OpenAI, or additional AI backends.
+- **JSON workbook persistence** using the `.aicalc` file extension for saving and loading multi-sheet projects.
+
+## Project layout
+
+```
+AiCalc.sln              # Solution file
+src/
+  AiCalc/              # UNO Platform single-project app
+    App.xaml           # Theme resources and global styles
+    App.xaml.cs        # Application bootstrapper
+    MainPage.xaml      # Primary shell with navigation and spreadsheet surface
+    Models/            # Workbook, sheet, cell, and settings models
+    ViewModels/        # MVVM state for workbook, sheets, rows, and cells
+    Services/          # Function registry and evaluation engine
+    Converters/        # UI value converters (automation glyphs, brushes, visibility)
+```
+
+## Getting started
+
+1. Install the [UNO Platform prerequisites](https://platform.uno/docs/articles/get-started.html).
+2. Restore and build the solution:
+   ```bash
+   dotnet restore
+   dotnet build
+   ```
+3. Run the desired head (Windows, WebAssembly, Android, iOS, or macOS) from Visual Studio or with `dotnet run -f net7.0-windows`.
+
+## Extending the function catalog
+
+The `FunctionRegistry` class registers built-in spreadsheet and AI helpers. New functions can be added by calling `Register` with a `FunctionDescriptor`. Each descriptor receives a `FunctionEvaluationContext` that exposes the workbook, current sheet, argument cells, and raw formula so you can orchestrate:
+
+- Native .NET logic
+- External agent flows via [Microsoft Agent Framework](https://github.com/microsoft/agent-framework/tree/main/dotnet)
+- Python scripts hosted in your runtime
+
+This design makes it straightforward to contribute additional AI skills or data utilities directly from C# or through Python interop.
+
+## Saving workbooks
+
+The **Save** and **Load** commands serialize the workbook to a friendly JSON payload with the `.aicalc` suffix. Serialized state captures:
+
+- Workbook metadata and connections
+- Sheet layout, row/column dimensions
+- Cell formulas, automation preferences, notes, and materialized values
+
+## Roadmap ideas
+
+- Real agent execution with background orchestration
+- Python function discovery and hot reloading
+- Collaborative editing and change tracking
+- Live previews for media cells (image/video/audio)
+- Advanced grid virtualization for large datasets
+
+> **Note:** This repository is a design-forward blueprint. Additional plumbing is required to reach production readiness, including runtime-specific heads, storage prompts, and integration with live AI providers.

--- a/src/AiCalc/AiCalc.csproj
+++ b/src/AiCalc/AiCalc.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net7.0-windows10.0.19041.0;net7.0-windows;net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0</TargetFrameworks>
+    <OutputType>WinExe</OutputType>
+    <UseWPF>false</UseWPF>
+    <UseWindowsForms>false</UseWindowsForms>
+    <SingleProject>true</SingleProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationManifest>App.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Uno.WinUI" Version="5.2.0" />
+    <PackageReference Include="Uno.Extensions.Reactive" Version="1.5.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="App.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="UnoWinUI" />
+  </ItemGroup>
+</Project>

--- a/src/AiCalc/App.manifest
+++ b/src/AiCalc/App.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="AiCalc.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/src/AiCalc/App.xaml
+++ b/src/AiCalc/App.xaml
@@ -1,0 +1,27 @@
+<Application
+    x:Class="AiCalc.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AiCalc">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+            </ResourceDictionary.MergedDictionaries>
+            <SolidColorBrush x:Key="SpreadsheetBackgroundBrush" Color="#FF101820" />
+            <SolidColorBrush x:Key="SpreadsheetCardBrush" Color="#FF1E2A33" />
+            <SolidColorBrush x:Key="SpreadsheetAccentBrush" Color="#FF4F9CFF" />
+            <SolidColorBrush x:Key="SpreadsheetAccentBrushAlt" Color="#FF00C853" />
+            <FontFamily x:Key="HeadingFont">Segoe UI Semibold</FontFamily>
+            <FontFamily x:Key="BodyFont">Segoe UI</FontFamily>
+            <Style x:Key="AccentButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="{StaticResource SpreadsheetAccentBrush}" />
+                <Setter Property="Foreground" Value="White" />
+                <Setter Property="CornerRadius" Value="8" />
+                <Setter Property="Padding" Value="16,8" />
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="FontFamily" Value="{StaticResource BodyFont}" />
+            </Style>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/src/AiCalc/App.xaml.cs
+++ b/src/AiCalc/App.xaml.cs
@@ -1,0 +1,34 @@
+using Microsoft.UI.Xaml;
+
+namespace AiCalc;
+
+public partial class App : Application
+{
+    private Window? _window;
+
+    public App()
+    {
+        InitializeComponent();
+        this.UnhandledException += OnUnhandledException;
+    }
+
+    private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine($"Unhandled exception: {e.Exception}" );
+    }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        base.OnLaunched(args);
+        if (_window is null)
+        {
+            _window = new Window
+            {
+                Title = "AiCalc Studio"
+            };
+            _window.Content = new MainPage();
+        }
+
+        _window.Activate();
+    }
+}

--- a/src/AiCalc/Converters/AutomationModeToGlyphConverter.cs
+++ b/src/AiCalc/Converters/AutomationModeToGlyphConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using AiCalc.Models;
+using Microsoft.UI.Xaml.Data;
+
+namespace AiCalc.Converters;
+
+public class AutomationModeToGlyphConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is CellAutomationMode mode)
+        {
+            return mode switch
+            {
+                CellAutomationMode.AutoOnOpen => "",
+                CellAutomationMode.AutoOnDependencyChange => "",
+                _ => ""
+            };
+        }
+
+        return "";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
+}

--- a/src/AiCalc/Converters/BooleanNegationConverter.cs
+++ b/src/AiCalc/Converters/BooleanNegationConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using Microsoft.UI.Xaml.Data;
+
+namespace AiCalc.Converters;
+
+public class BooleanNegationConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool flag)
+        {
+            return !flag;
+        }
+
+        return true;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotSupportedException();
+}

--- a/src/AiCalc/Converters/BooleanToBrushConverter.cs
+++ b/src/AiCalc/Converters/BooleanToBrushConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+
+namespace AiCalc.Converters;
+
+public class BooleanToBrushConverter : IValueConverter
+{
+    public Brush? TrueBrush { get; set; }
+
+    public Brush? FalseBrush { get; set; }
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool flag)
+        {
+            return flag ? TrueBrush ?? new SolidColorBrush(Windows.UI.Color.FromArgb(255, 79, 156, 255)) : FalseBrush ?? new SolidColorBrush(Windows.UI.Color.FromArgb(255, 30, 42, 51));
+        }
+
+        return FalseBrush ?? new SolidColorBrush(Windows.UI.Color.FromArgb(255, 30, 42, 51));
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotSupportedException();
+}

--- a/src/AiCalc/Converters/BooleanToVisibilityConverter.cs
+++ b/src/AiCalc/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace AiCalc.Converters;
+
+public class BooleanToVisibilityConverter : IValueConverter
+{
+    public bool CollapseWhenFalse { get; set; } = true;
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool flag && flag)
+        {
+            return Visibility.Visible;
+        }
+
+        return CollapseWhenFalse ? Visibility.Collapsed : Visibility.Hidden;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotSupportedException();
+}

--- a/src/AiCalc/Converters/InverseBooleanToVisibilityConverter.cs
+++ b/src/AiCalc/Converters/InverseBooleanToVisibilityConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace AiCalc.Converters;
+
+public class InverseBooleanToVisibilityConverter : IValueConverter
+{
+    public bool CollapseWhenTrue { get; set; } = true;
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool flag && flag)
+        {
+            return CollapseWhenTrue ? Visibility.Collapsed : Visibility.Hidden;
+        }
+
+        return Visibility.Visible;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotSupportedException();
+}

--- a/src/AiCalc/MainPage.xaml
+++ b/src/AiCalc/MainPage.xaml
@@ -1,0 +1,279 @@
+<Page x:Name="PageRoot"
+    x:Class="AiCalc.MainPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AiCalc"
+    xmlns:services="using:AiCalc.Services"
+    xmlns:models="using:AiCalc.Models"
+    xmlns:vm="using:AiCalc.ViewModels"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:conv="using:AiCalc.Converters"
+    mc:Ignorable="d"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008">
+
+    <Page.Resources>
+        <conv:BooleanToBrushConverter x:Key="CellSelectionBrushConverter"
+                                       TrueBrush="{StaticResource SpreadsheetAccentBrush}"
+                                       FalseBrush="{StaticResource SpreadsheetCardBrush}" />
+        <conv:AutomationModeToGlyphConverter x:Key="AutomationGlyphConverter" />
+        <conv:BooleanNegationConverter x:Key="BooleanNegationConverter" />
+        <conv:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <conv:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
+        <Style x:Key="CellButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        </Style>
+    </Page.Resources>
+
+    <Grid Background="{StaticResource SpreadsheetBackgroundBrush}">
+        <NavigationView x:Name="RootNavigation"
+                        IsSettingsVisible="True"
+                        PaneDisplayMode="Top"
+                        AlwaysShowHeader="True"
+                        IsPaneToggleButtonVisible="False"
+                        IsTitleBarAutoPaddingEnabled="False">
+            <NavigationView.MenuItems>
+                <NavigationViewItem Icon="Home" Content="Dashboard" />
+                <NavigationViewItem Icon="Library" Content="Functions" />
+                <NavigationViewItem Icon="Settings" Content="Settings" />
+            </NavigationView.MenuItems>
+
+            <NavigationView.Header>
+                <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                    <TextBlock Text="AiCalc Studio" FontSize="18" FontFamily="{StaticResource HeadingFont}" Foreground="White" />
+                    <TextBox Width="240"
+                             PlaceholderText="Workbook title"
+                             Text="{x:Bind ViewModel.Title, Mode=TwoWay}"
+                             FontFamily="{StaticResource BodyFont}" />
+                    <Button Content="New Sheet"
+                            Command="{x:Bind ViewModel.NewSheetCommand}"
+                            Style="{StaticResource AccentButtonStyle}" />
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <Button Content="Evaluate Sheet"
+                                Command="{x:Bind ViewModel.EvaluateSheetCommand}"
+                                Style="{StaticResource AccentButtonStyle}" />
+                        <Button Content="Evaluate All"
+                                Command="{x:Bind ViewModel.EvaluateWorkbookCommand}"
+                                Style="{StaticResource AccentButtonStyle}" />
+                        <Button Content="Save"
+                                Command="{x:Bind ViewModel.SaveCommand}"
+                                Style="{StaticResource AccentButtonStyle}" />
+                        <Button Content="Load"
+                                Command="{x:Bind ViewModel.LoadCommand}"
+                                Style="{StaticResource AccentButtonStyle}" />
+                    </StackPanel>
+                </StackPanel>
+            </NavigationView.Header>
+
+            <NavigationView.Content>
+                <Grid Padding="24" ColumnSpacing="16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="320" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="360" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Spacing="16">
+                        <Border Background="{StaticResource SpreadsheetCardBrush}"
+                                Padding="16"
+                                CornerRadius="12">
+                            <StackPanel Spacing="12">
+                                <TextBlock Text="Function Explorer"
+                                           Foreground="White"
+                                           FontFamily="{StaticResource HeadingFont}"
+                                           FontSize="18" />
+                                <TextBox PlaceholderText="Search functions" />
+                                <ListView ItemsSource="{x:Bind ViewModel.FunctionRegistry.Functions}"
+                                          SelectionMode="Single"
+                                          MinHeight="260">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="services:FunctionDescriptor">
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="{x:Bind Name}" Foreground="White" FontWeight="SemiBold" />
+                                                <TextBlock Text="{x:Bind Description}"
+                                                           TextWrapping="Wrap"
+                                                           Foreground="#AAFFFFFF"
+                                                           FontSize="12" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Background="{StaticResource SpreadsheetCardBrush}"
+                                Padding="16"
+                                CornerRadius="12">
+                            <StackPanel Spacing="12">
+                                <TextBlock Text="Connections"
+                                           Foreground="White"
+                                           FontFamily="{StaticResource HeadingFont}" />
+                                <ListView ItemsSource="{x:Bind ViewModel.Settings.Connections}" MinHeight="120">
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="models:WorkspaceConnection">
+                                            <StackPanel>
+                                                <TextBlock Text="{x:Bind Name}" Foreground="White" />
+                                                <TextBlock Text="{x:Bind Provider}" Foreground="#AAFFFFFF" FontSize="12" />
+                                                <TextBlock Text="{x:Bind Endpoint}" Foreground="#66FFFFFF" FontSize="10" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                                <Button Content="Add Connection" Style="{StaticResource AccentButtonStyle}" />
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+
+                    <Border Grid.Column="1"
+                            Background="{StaticResource SpreadsheetCardBrush}"
+                            Padding="12"
+                            CornerRadius="12">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <muxc:TabView TabWidthMode="Equal"
+                                          ItemsSource="{x:Bind ViewModel.Sheets}"
+                                          SelectedItem="{x:Bind ViewModel.SelectedSheet, Mode=TwoWay}">
+                                <muxc:TabView.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:SheetViewModel">
+                                        <TextBlock Text="{x:Bind Name}" />
+                                    </DataTemplate>
+                                </muxc:TabView.ItemTemplate>
+                                <muxc:TabView.ContentTemplate>
+                                    <DataTemplate x:DataType="vm:SheetViewModel">
+                                        <Grid>
+                                            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                                          VerticalScrollBarVisibility="Auto">
+                                                <StackPanel>
+                                                    <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,12">
+                                                        <Border Width="48" Background="#33000000" CornerRadius="8" Padding="8" />
+                                                        <ItemsRepeater ItemsSource="{x:Bind ColumnHeaders}">
+                                                            <ItemsRepeater.Layout>
+                                                                <muxc:StackLayout Orientation="Horizontal" />
+                                                            </ItemsRepeater.Layout>
+                                                            <ItemsRepeater.ItemTemplate>
+                                                                <DataTemplate x:DataType="x:String">
+                                                                    <Border Width="120" Background="#33000000" CornerRadius="8" Padding="8">
+                                                                        <TextBlock Text="{x:Bind}" Foreground="#CCFFFFFF" HorizontalAlignment="Center" />
+                                                                    </Border>
+                                                                </DataTemplate>
+                                                            </ItemsRepeater.ItemTemplate>
+                                                        </ItemsRepeater>
+                                                    </StackPanel>
+                                                    <ItemsRepeater ItemsSource="{x:Bind Rows}">
+                                                        <ItemsRepeater.Layout>
+                                                            <muxc:StackLayout Orientation="Vertical" />
+                                                        </ItemsRepeater.Layout>
+                                                        <ItemsRepeater.ItemTemplate>
+                                                            <DataTemplate x:DataType="vm:RowViewModel">
+                                                                <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                                                                    <Border Width="48"
+                                                                            Background="#33000000"
+                                                                            CornerRadius="8"
+                                                                            Padding="8"
+                                                                            VerticalAlignment="Stretch">
+                                                                        <TextBlock Text="{x:Bind Label, Mode=OneWay}"
+                                                                                   Foreground="#88FFFFFF"
+                                                                                   HorizontalAlignment="Center" />
+                                                                    </Border>
+                                                                    <ItemsRepeater ItemsSource="{x:Bind Cells}">
+                                                                        <ItemsRepeater.Layout>
+                                                                            <muxc:StackLayout Orientation="Horizontal" />
+                                                                        </ItemsRepeater.Layout>
+                                                                        <ItemsRepeater.ItemTemplate>
+                                                                            <DataTemplate x:DataType="vm:CellViewModel">
+                                                                                <Button Command="{x:Bind Sheet.Workbook.SelectCellCommand}"
+                                                                                        CommandParameter="{x:Bind}"
+                                                                                        Style="{StaticResource CellButtonStyle}"
+                                                                                        HorizontalAlignment="Stretch"
+                                                                                        VerticalAlignment="Stretch">
+                                                                                    <Border Width="120"
+                                                                                            Height="72"
+                                                                                            Padding="8"
+                                                                                            Background="{Binding IsSelected, Converter={StaticResource CellSelectionBrushConverter}}"
+                                                                                            CornerRadius="10"
+                                                                                            BorderBrush="#11FFFFFF"
+                                                                                            BorderThickness="1"
+                                                                                            ToolTipService.ToolTip="{x:Bind DisplayLabel}">
+                                                                                        <StackPanel>
+                                                                                            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                                                                                <FontIcon Glyph="{x:Bind ObjectTypeGlyph}" Foreground="White" />
+                                                                                                <FontIcon Glyph="{Binding AutomationMode, Converter={StaticResource AutomationGlyphConverter}}" Foreground="#AAFFFFFF" />
+                                                                                                <TextBlock Text="{x:Bind DisplayLabel}"
+                                                                                                           Foreground="#AAFFFFFF"
+                                                                                                           FontSize="12" />
+                                                                                            </StackPanel>
+                                                                                            <TextBlock Text="{x:Bind DisplayValue}"
+                                                                                                       TextWrapping="Wrap"
+                                                                                                       Foreground="White"
+                                                                                                       FontSize="14"
+                                                                                                       Margin="0,6,0,0" />
+                                                                                        </StackPanel>
+                                                                                    </Border>
+                                                                                </Button>
+                                                                            </DataTemplate>
+                                                                        </ItemsRepeater.ItemTemplate>
+                                                                    </ItemsRepeater>
+                                                                </StackPanel>
+                                                            </DataTemplate>
+                                                        </ItemsRepeater.ItemTemplate>
+                                                    </ItemsRepeater>
+                                                </StackPanel>
+                                            </ScrollViewer>
+                                        </Grid>
+                                    </DataTemplate>
+                                </muxc:TabView.ContentTemplate>
+                            </muxc:TabView>
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Column="2"
+                            Background="{StaticResource SpreadsheetCardBrush}"
+                            Padding="20"
+                            CornerRadius="12">
+                        <StackPanel Spacing="16">
+                            <TextBlock Text="Cell Inspector"
+                                       Foreground="White"
+                                       FontFamily="{StaticResource HeadingFont}"
+                                       FontSize="18" />
+                            <StackPanel Visibility="{Binding Source={x:Reference Name=PageRoot}, Path=DataContext.HasActiveCell, Converter={StaticResource BooleanToVisibilityConverter}}" Spacing="12"
+                                DataContext="{Binding Source={x:Reference Name=PageRoot}, Path=DataContext.ActiveCell}">
+                                <TextBlock Text="{Binding DisplayLabel}" Foreground="White" FontSize="16" />
+                                <TextBlock Text="Value" Foreground="#AAFFFFFF" />
+                                <TextBox Text="{Binding RawValue, Mode=TwoWay}" AcceptsReturn="True" Height="60" />
+                                <TextBlock Text="Formula" Foreground="#AAFFFFFF" />
+                                <TextBox Text="{Binding Formula, Mode=TwoWay}" PlaceholderText="=SUM(Sheet1!A1,Sheet1!A2)" />
+                                <TextBlock Text="Automation" Foreground="#AAFFFFFF" />
+                                <ComboBox ItemsSource="{Binding Source={x:Reference Name=PageRoot}, Path=DataContext.AutomationModes}"
+                                          SelectedItem="{Binding AutomationMode, Mode=TwoWay}" />
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <Button Content="Run"
+                                            Command="{Binding RunCommand}"
+                                            Style="{StaticResource AccentButtonStyle}" />
+                                    <Button Content="Clear"
+                                            Command="{Binding Source={x:Reference Name=PageRoot}, Path=DataContext.ClearSelectionCommand}"
+                                            Style="{StaticResource AccentButtonStyle}" />
+                                </StackPanel>
+                                <TextBlock Text="Notes" Foreground="#AAFFFFFF" />
+                                <TextBox Text="{Binding Notes, Mode=TwoWay}" AcceptsReturn="True" Height="60" />
+                            </StackPanel>
+                            <TextBlock Text="Select a cell to edit." Foreground="#55FFFFFF" Visibility="{Binding Source={x:Reference Name=PageRoot}, Path=DataContext.HasActiveCell, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </NavigationView.Content>
+        </NavigationView>
+
+        <Grid VerticalAlignment="Bottom" Background="#22000000" Height="36" Padding="16,0">
+            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                <ProgressRing Width="20" Height="20" IsActive="{x:Bind ViewModel.IsBusy}" Foreground="{StaticResource SpreadsheetAccentBrush}" />
+                <TextBlock Text="{x:Bind ViewModel.StatusMessage}" Foreground="#AAFFFFFF" />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Page>

--- a/src/AiCalc/MainPage.xaml.cs
+++ b/src/AiCalc/MainPage.xaml.cs
@@ -1,0 +1,17 @@
+using AiCalc.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace AiCalc;
+
+public sealed partial class MainPage : Page
+{
+    public MainPage()
+    {
+        ViewModel = new WorkbookViewModel();
+        InitializeComponent();
+        DataContext = ViewModel;
+    }
+
+    public WorkbookViewModel ViewModel { get; }
+}

--- a/src/AiCalc/Models/CellAddress.cs
+++ b/src/AiCalc/Models/CellAddress.cs
@@ -1,0 +1,75 @@
+namespace AiCalc.Models;
+
+public readonly record struct CellAddress(string SheetName, int Row, int Column)
+{
+    public override string ToString()
+    {
+        var colName = ColumnIndexToName(Column);
+        return $"{SheetName}!{colName}{Row + 1}";
+    }
+
+    public static bool TryParse(string input, string defaultSheet, out CellAddress address)
+    {
+        address = default;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        var sheetSplit = input.Split('!');
+        string sheet = defaultSheet;
+        string cellPart;
+
+        if (sheetSplit.Length == 2)
+        {
+            sheet = sheetSplit[0];
+            cellPart = sheetSplit[1];
+        }
+        else
+        {
+            cellPart = sheetSplit[0];
+        }
+
+        int column = 0;
+        int rowIndex = -1;
+        foreach (var ch in cellPart)
+        {
+            if (char.IsLetter(ch))
+            {
+                column = column * 26 + (char.ToUpperInvariant(ch) - 'A' + 1);
+            }
+            else if (char.IsDigit(ch))
+            {
+                rowIndex = rowIndex < 0 ? 0 : rowIndex;
+                rowIndex = rowIndex * 10 + (ch - '0');
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        if (rowIndex < 1 || column < 1)
+        {
+            return false;
+        }
+
+        address = new CellAddress(sheet, rowIndex - 1, column - 1);
+        return true;
+    }
+
+    public static string ColumnIndexToName(int columnIndex)
+    {
+        int dividend = columnIndex + 1;
+        string columnName = string.Empty;
+
+        while (dividend > 0)
+        {
+            int modulo = (dividend - 1) % 26;
+            columnName = Convert.ToChar('A' + modulo) + columnName;
+            dividend = (dividend - modulo) // 26;
+        }
+
+        return columnName;
+    }
+}

--- a/src/AiCalc/Models/CellAutomationMode.cs
+++ b/src/AiCalc/Models/CellAutomationMode.cs
@@ -1,0 +1,8 @@
+namespace AiCalc.Models;
+
+public enum CellAutomationMode
+{
+    Manual,
+    AutoOnOpen,
+    AutoOnDependencyChange
+}

--- a/src/AiCalc/Models/CellDefinition.cs
+++ b/src/AiCalc/Models/CellDefinition.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace AiCalc.Models;
+
+public class CellDefinition
+{
+    public string Address { get; set; } = string.Empty;
+
+    public string? Formula { get; set; }
+
+    public CellValue Value { get; set; } = CellValue.Empty;
+
+    public CellAutomationMode AutomationMode { get; set; } = CellAutomationMode.Manual;
+
+    public string? Notes { get; set; }
+
+    public string? SourcePath { get; set; }
+}

--- a/src/AiCalc/Models/CellObjectType.cs
+++ b/src/AiCalc/Models/CellObjectType.cs
@@ -1,0 +1,21 @@
+namespace AiCalc.Models;
+
+public enum CellObjectType
+{
+    Empty,
+    Number,
+    Text,
+    Boolean,
+    DateTime,
+    Image,
+    Audio,
+    Video,
+    Directory,
+    File,
+    Table,
+    Script,
+    Json,
+    Markdown,
+    Link,
+    Error
+}

--- a/src/AiCalc/Models/CellValue.cs
+++ b/src/AiCalc/Models/CellValue.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace AiCalc.Models;
+
+public record CellValue
+{
+    [JsonConstructor]
+    public CellValue(CellObjectType objectType, string? serializedValue = null, string? displayValue = null)
+    {
+        ObjectType = objectType;
+        SerializedValue = serializedValue;
+        DisplayValue = displayValue;
+    }
+
+    public CellValue()
+    {
+    }
+
+    public CellObjectType ObjectType { get; set; }
+
+    public string? SerializedValue { get; set; }
+
+    public string? DisplayValue { get; set; }
+
+    public static CellValue Empty { get; } = new(CellObjectType.Empty, null, string.Empty);
+}

--- a/src/AiCalc/Models/SheetDefinition.cs
+++ b/src/AiCalc/Models/SheetDefinition.cs
@@ -1,0 +1,14 @@
+using System.Collections.ObjectModel;
+
+namespace AiCalc.Models;
+
+public class SheetDefinition
+{
+    public string Name { get; set; } = "Sheet1";
+
+    public ObservableCollection<CellDefinition> Cells { get; set; } = new();
+
+    public int ColumnCount { get; set; } = 8;
+
+    public int RowCount { get; set; } = 12;
+}

--- a/src/AiCalc/Models/WorkbookDefinition.cs
+++ b/src/AiCalc/Models/WorkbookDefinition.cs
@@ -1,0 +1,12 @@
+using System.Collections.ObjectModel;
+
+namespace AiCalc.Models;
+
+public class WorkbookDefinition
+{
+    public string Title { get; set; } = "AiCalc Workbook";
+
+    public ObservableCollection<SheetDefinition> Sheets { get; set; } = new();
+
+    public WorkbookSettings Settings { get; set; } = new();
+}

--- a/src/AiCalc/Models/WorkbookSettings.cs
+++ b/src/AiCalc/Models/WorkbookSettings.cs
@@ -1,0 +1,14 @@
+using System.Collections.ObjectModel;
+
+namespace AiCalc.Models;
+
+public class WorkbookSettings
+{
+    public ObservableCollection<WorkspaceConnection> Connections { get; set; } = new();
+
+    public string DefaultImageModel { get; set; } = "stable-diffusion";
+
+    public string DefaultTextModel { get; set; } = "gpt-4";
+
+    public string DefaultVideoModel { get; set; } = "gen-2";
+}

--- a/src/AiCalc/Models/WorkspaceConnection.cs
+++ b/src/AiCalc/Models/WorkspaceConnection.cs
@@ -1,0 +1,14 @@
+namespace AiCalc.Models;
+
+public class WorkspaceConnection
+{
+    public string Name { get; set; } = "Local Runtime";
+
+    public string Provider { get; set; } = "Local";
+
+    public string Endpoint { get; set; } = "http://localhost";
+
+    public string ApiKey { get; set; } = string.Empty;
+
+    public bool IsDefault { get; set; }
+}

--- a/src/AiCalc/Services/FunctionDescriptor.cs
+++ b/src/AiCalc/Services/FunctionDescriptor.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiCalc.Models;
+using AiCalc.ViewModels;
+
+namespace AiCalc.Services;
+
+public class FunctionDescriptor
+{
+    public FunctionDescriptor(string name, string description, Func<FunctionEvaluationContext, Task<FunctionExecutionResult>> handler, params FunctionParameter[] parameters)
+    {
+        Name = name;
+        Description = description;
+        Handler = handler;
+        Parameters = parameters;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public IReadOnlyList<FunctionParameter> Parameters { get; }
+
+    public Func<FunctionEvaluationContext, Task<FunctionExecutionResult>> Handler { get; }
+}
+
+public class FunctionParameter
+{
+    public FunctionParameter(string name, string description, CellObjectType expectedType, bool isOptional = false)
+    {
+        Name = name;
+        Description = description;
+        ExpectedType = expectedType;
+        IsOptional = isOptional;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public CellObjectType ExpectedType { get; }
+
+    public bool IsOptional { get; }
+}
+
+public record FunctionExecutionResult(CellValue Value, string? Diagnostics = null);
+
+public record FunctionEvaluationContext(WorkbookViewModel Workbook, SheetViewModel Sheet, IReadOnlyList<CellViewModel> Arguments, string RawFormula);

--- a/src/AiCalc/Services/FunctionRegistry.cs
+++ b/src/AiCalc/Services/FunctionRegistry.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiCalc.Models;
+using AiCalc.ViewModels;
+
+namespace AiCalc.Services;
+
+public class FunctionRegistry
+{
+    private readonly Dictionary<string, FunctionDescriptor> _functions = new(StringComparer.OrdinalIgnoreCase);
+
+    public FunctionRegistry()
+    {
+        RegisterBuiltIns();
+    }
+
+    public IReadOnlyCollection<FunctionDescriptor> Functions => _functions.Values.OrderBy(f => f.Name).ToList();
+
+    public bool TryGet(string name, out FunctionDescriptor descriptor) => _functions.TryGetValue(name, out descriptor!);
+
+    public void Register(FunctionDescriptor descriptor)
+    {
+        _functions[descriptor.Name] = descriptor;
+    }
+
+    private void RegisterBuiltIns()
+    {
+        Register(new FunctionDescriptor(
+            "SUM",
+            "Adds a series of numbers.",
+            async ctx =>
+            {
+                await Task.CompletedTask;
+                var sum = ctx.Arguments.Sum(cell => double.TryParse(cell.DisplayValue, out var value) ? value : 0);
+                return new FunctionExecutionResult(new CellValue(CellObjectType.Number, sum.ToString(), sum.ToString()), $"Summed {ctx.Arguments.Count} cells");
+            },
+            new FunctionParameter("values", "Range of values to add.", CellObjectType.Number)));
+
+        Register(new FunctionDescriptor(
+            "CONCAT",
+            "Concatenates string values.",
+            async ctx =>
+            {
+                await Task.CompletedTask;
+                var text = string.Join("", ctx.Arguments.Select(cell => cell.DisplayValue));
+                return new FunctionExecutionResult(new CellValue(CellObjectType.Text, text, text));
+            },
+            new FunctionParameter("values", "Values to concatenate.", CellObjectType.Text)));
+
+        Register(new FunctionDescriptor(
+            "TEXT_TO_IMAGE",
+            "Generates an image description placeholder for a prompt.",
+            async ctx =>
+            {
+                await Task.CompletedTask;
+                var prompt = ctx.Arguments.FirstOrDefault()?.DisplayValue ?? string.Empty;
+                var metadata = $"image://generated/{Guid.NewGuid():N}.png";
+                return new FunctionExecutionResult(new CellValue(CellObjectType.Image, metadata, $"Image from '{prompt}'"));
+            },
+            new FunctionParameter("prompt", "Prompt text", CellObjectType.Text)));
+
+        Register(new FunctionDescriptor(
+            "IMAGE_TO_TEXT",
+            "Describes an image as text.",
+            async ctx =>
+            {
+                await Task.CompletedTask;
+                var description = $"Caption for {ctx.Arguments.FirstOrDefault()?.DisplayValue}";
+                return new FunctionExecutionResult(new CellValue(CellObjectType.Text, description, description));
+            },
+            new FunctionParameter("image", "Image cell", CellObjectType.Image)));
+
+        Register(new FunctionDescriptor(
+            "DIRECTORY_TO_TABLE",
+            "Expands a directory listing into a table value.",
+            async ctx =>
+            {
+                await Task.CompletedTask;
+                var path = ctx.Arguments.FirstOrDefault()?.DisplayValue ?? string.Empty;
+                var json = $"[{{"name":"sample.txt","size":1024}},{{"name":"image.png","size":2048}}]";
+                return new FunctionExecutionResult(new CellValue(CellObjectType.Table, json, $"Directory snapshot: {path}"));
+            },
+            new FunctionParameter("directory", "Directory path", CellObjectType.Directory)));
+    }
+}

--- a/src/AiCalc/Services/FunctionRunner.cs
+++ b/src/AiCalc/Services/FunctionRunner.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using AiCalc.Models;
+using AiCalc.ViewModels;
+
+namespace AiCalc.Services;
+
+public class FunctionRunner
+{
+    private static readonly Regex FunctionRegex = new("^=?(?<name>[A-Z0-9_]+)\((?<args>.*)\)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public FunctionRunner(FunctionRegistry registry)
+    {
+        Registry = registry;
+    }
+
+    public FunctionRegistry Registry { get; }
+
+    public async Task<FunctionExecutionResult?> EvaluateAsync(CellViewModel cell, string formula)
+    {
+        if (!FunctionRegex.IsMatch(formula))
+        {
+            return null;
+        }
+
+        var match = FunctionRegex.Match(formula);
+        var name = match.Groups["name"].Value;
+        var args = match.Groups["args"].Value;
+
+        if (!Registry.TryGet(name, out var descriptor))
+        {
+            throw new InvalidOperationException($"Unknown function '{name}'.");
+        }
+
+        var arguments = await ResolveArgumentsAsync(cell.Sheet, args);
+        var context = new FunctionEvaluationContext(cell.Sheet.Workbook, cell.Sheet, arguments, formula);
+        return await descriptor.Handler(context);
+    }
+
+    private async Task<IReadOnlyList<CellViewModel>> ResolveArgumentsAsync(SheetViewModel sheet, string args)
+    {
+        await Task.CompletedTask;
+        var workbook = sheet.Workbook;
+        var results = new List<CellViewModel>();
+
+        foreach (var token in SplitArguments(args))
+        {
+            if (CellAddress.TryParse(token.Trim(), sheet.Name, out var address))
+            {
+                var targetSheet = workbook.GetSheet(address.SheetName) ?? sheet;
+                var cell = targetSheet.GetCell(address.Row, address.Column);
+                if (cell is not null)
+                {
+                    results.Add(cell);
+                }
+            }
+            else if (double.TryParse(token, out var number))
+            {
+                var temp = new CellViewModel(workbook, sheet, 0, 0)
+                {
+                    Value = new CellValue(CellObjectType.Number, number.ToString(), number.ToString())
+                };
+                results.Add(temp);
+            }
+            else if (token.StartsWith('"') && token.EndsWith('"'))
+            {
+                var text = token.Trim('"');
+                var temp = new CellViewModel(workbook, sheet, 0, 0)
+                {
+                    Value = new CellValue(CellObjectType.Text, text, text)
+                };
+                results.Add(temp);
+            }
+        }
+
+        return results;
+    }
+
+    private static IEnumerable<string> SplitArguments(string args)
+    {
+        if (string.IsNullOrWhiteSpace(args))
+        {
+            yield break;
+        }
+
+        int depth = 0;
+        var current = new List<char>();
+        foreach (var ch in args)
+        {
+            if (ch == '(')
+            {
+                depth++;
+            }
+            else if (ch == ')')
+            {
+                depth--;
+            }
+
+            if (ch == ',' && depth == 0)
+            {
+                yield return new string(current.ToArray());
+                current.Clear();
+            }
+            else
+            {
+                current.Add(ch);
+            }
+        }
+
+        if (current.Count > 0)
+        {
+            yield return new string(current.ToArray());
+        }
+    }
+}

--- a/src/AiCalc/ViewModels/BaseViewModel.cs
+++ b/src/AiCalc/ViewModels/BaseViewModel.cs
@@ -1,0 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AiCalc.ViewModels;
+
+public abstract partial class BaseViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private string? _statusMessage;
+}

--- a/src/AiCalc/ViewModels/CellViewModel.cs
+++ b/src/AiCalc/ViewModels/CellViewModel.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiCalc.Models;
+using AiCalc.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AiCalc.ViewModels;
+
+public partial class CellViewModel : ObservableObject
+{
+    private readonly WorkbookViewModel _workbook;
+
+    public CellViewModel(WorkbookViewModel workbook, SheetViewModel sheet, int row, int column)
+    {
+        _workbook = workbook;
+        Sheet = sheet;
+        Row = row;
+        Column = column;
+        Address = new CellAddress(sheet.Name, row, column);
+    }
+
+    public SheetViewModel Sheet { get; }
+
+    public int Row { get; }
+
+    public int Column { get; }
+
+    public CellAddress Address { get; }
+
+    [ObservableProperty]
+    private string? _formula;
+
+    [ObservableProperty]
+    private CellValue _value = CellValue.Empty;
+
+    [ObservableProperty]
+    private CellAutomationMode _automationMode = CellAutomationMode.Manual;
+
+    [ObservableProperty]
+    private string? _notes;
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    public string DisplayLabel => Address.ToString();
+
+    public string ObjectTypeGlyph => Value.ObjectType switch
+    {
+        CellObjectType.Number => "",
+        CellObjectType.Text => "",
+        CellObjectType.Image => "",
+        CellObjectType.Video => "",
+        CellObjectType.Audio => "",
+        CellObjectType.Directory => "",
+        CellObjectType.File => "",
+        CellObjectType.Table => "",
+        CellObjectType.Script => "",
+        CellObjectType.Markdown => "",
+        CellObjectType.Json => "{}",
+        CellObjectType.Link => "",
+        CellObjectType.Error => "⚠",
+        _ => "○"
+    };
+
+    public string DisplayValue => string.IsNullOrWhiteSpace(Value.DisplayValue) ? Value.SerializedValue ?? string.Empty : Value.DisplayValue;
+
+    public string? RawValue
+    {
+        get => Value.SerializedValue;
+        set
+        {
+            var objectType = Value.ObjectType == CellObjectType.Empty && !string.IsNullOrWhiteSpace(value) ? CellObjectType.Text : Value.ObjectType;
+            var display = string.IsNullOrWhiteSpace(Value.DisplayValue) ? value : Value.DisplayValue;
+            Value = new CellValue(objectType, value, display);
+        }
+    }
+
+    public bool HasFormula => !string.IsNullOrWhiteSpace(Formula);
+
+    public async Task EvaluateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Formula))
+        {
+            return;
+        }
+
+        try
+        {
+            _workbook.IsBusy = true;
+            _workbook.StatusMessage = $"Evaluating {Address}...";
+            var result = await _workbook.FunctionRunner.EvaluateAsync(this, Formula);
+            if (result is not null)
+            {
+                Value = result.Value;
+            }
+        }
+        catch (Exception ex)
+        {
+            Value = new CellValue(CellObjectType.Error, ex.Message, ex.Message);
+        }
+        finally
+        {
+            _workbook.StatusMessage = null;
+            _workbook.IsBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private Task RunAsync() => EvaluateAsync();
+
+    partial void OnValueChanged(CellValue value)
+    {
+        OnPropertyChanged(nameof(DisplayValue));
+        OnPropertyChanged(nameof(ObjectTypeGlyph));
+        OnPropertyChanged(nameof(RawValue));
+    }
+}
+

--- a/src/AiCalc/ViewModels/RowViewModel.cs
+++ b/src/AiCalc/ViewModels/RowViewModel.cs
@@ -1,0 +1,17 @@
+using System.Collections.ObjectModel;
+
+namespace AiCalc.ViewModels;
+
+public class RowViewModel
+{
+    public RowViewModel(int rowIndex)
+    {
+        Index = rowIndex;
+    }
+
+    public int Index { get; }
+
+    public string Label => (Index + 1).ToString();
+
+    public ObservableCollection<CellViewModel> Cells { get; } = new();
+}

--- a/src/AiCalc/ViewModels/SheetViewModel.cs
+++ b/src/AiCalc/ViewModels/SheetViewModel.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using AiCalc.Models;
+
+namespace AiCalc.ViewModels;
+
+public class SheetViewModel
+{
+    private readonly WorkbookViewModel _workbook;
+
+    public SheetViewModel(WorkbookViewModel workbook, string name, int rows, int columns)
+    {
+        _workbook = workbook;
+        Workbook = workbook;
+        Name = name;
+        Rows = new ObservableCollection<RowViewModel>(Enumerable.Range(0, rows).Select(r => CreateRow(r, columns)));
+    }
+
+    public WorkbookViewModel Workbook { get; }
+
+    public string Name { get; }
+
+    public ObservableCollection<RowViewModel> Rows { get; }
+
+    public int ColumnCount => Rows.FirstOrDefault()?.Cells.Count ?? 0;
+
+    public IReadOnlyList<string> ColumnHeaders => Enumerable.Range(0, ColumnCount).Select(CellAddress.ColumnIndexToName).ToList();
+
+    public CellViewModel? GetCell(int row, int column)
+    {
+        if (row < 0 || row >= Rows.Count)
+        {
+            return null;
+        }
+
+        var rowVm = Rows[row];
+        if (column < 0 || column >= rowVm.Cells.Count)
+        {
+            return null;
+        }
+
+        return rowVm.Cells[column];
+    }
+
+    public IEnumerable<CellViewModel> Cells => Rows.SelectMany(r => r.Cells);
+
+    public async Task EvaluateAllAsync()
+    {
+        foreach (var cell in Cells.Where(c => c.HasFormula))
+        {
+            if (cell.AutomationMode != CellAutomationMode.Manual)
+            {
+                await cell.EvaluateAsync();
+            }
+        }
+    }
+
+    private RowViewModel CreateRow(int rowIndex, int columnCount)
+    {
+        var row = new RowViewModel(rowIndex);
+        for (var col = 0; col < columnCount; col++)
+        {
+            row.Cells.Add(new CellViewModel(_workbook, this, rowIndex, col));
+        }
+
+        return row;
+    }
+}

--- a/src/AiCalc/ViewModels/WorkbookViewModel.cs
+++ b/src/AiCalc/ViewModels/WorkbookViewModel.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using AiCalc.Models;
+using AiCalc.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace AiCalc.ViewModels;
+
+public partial class WorkbookViewModel : BaseViewModel
+{
+    private readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public WorkbookViewModel()
+    {
+        FunctionRegistry = new FunctionRegistry();
+        FunctionRunner = new FunctionRunner(FunctionRegistry);
+        Sheets = new ObservableCollection<SheetViewModel>();
+        Settings.Connections.Add(new WorkspaceConnection { Name = "Local Python Runtime", Provider = "Python", Endpoint = "local://python", IsDefault = true });
+        Settings.Connections.Add(new WorkspaceConnection { Name = "Ollama", Provider = "Ollama", Endpoint = "http://localhost:11434" });
+        Settings.Connections.Add(new WorkspaceConnection { Name = "Azure OpenAI", Provider = "Azure OpenAI", Endpoint = "https://api.contoso.azure.com" });
+        AddSheet();
+        SelectedSheet = Sheets.FirstOrDefault();
+    }
+
+    public FunctionRegistry FunctionRegistry { get; }
+
+    public FunctionRunner FunctionRunner { get; }
+
+    public ObservableCollection<SheetViewModel> Sheets { get; }
+
+    public Array AutomationModes { get; } = Enum.GetValues(typeof(CellAutomationMode));
+
+    [ObservableProperty]
+    private SheetViewModel? _selectedSheet;
+
+    [ObservableProperty]
+    private WorkbookSettings _settings = new();
+
+    [ObservableProperty]
+    private string _title = "Untitled Workbook";
+
+    [ObservableProperty]
+    private CellViewModel? _activeCell;
+
+    public bool HasActiveCell => ActiveCell is not null;
+
+    partial void OnActiveCellChanged(CellViewModel? oldValue, CellViewModel? newValue)
+    {
+        foreach (var cell in Sheets.SelectMany(s => s.Cells))
+        {
+            cell.IsSelected = cell == newValue;
+        }
+
+        OnPropertyChanged(nameof(HasActiveCell));
+    }
+
+    public void AddSheet()
+    {
+        var index = Sheets.Count + 1;
+        var sheet = new SheetViewModel(this, $"Sheet{index}", 20, 12);
+        Sheets.Add(sheet);
+    }
+
+    public SheetViewModel? GetSheet(string name) => Sheets.FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+    public CellViewModel? GetCell(CellAddress address)
+    {
+        var sheet = GetSheet(address.SheetName);
+        return sheet?.GetCell(address.Row, address.Column);
+    }
+
+    [RelayCommand]
+    private void NewSheet()
+    {
+        AddSheet();
+        SelectedSheet = Sheets.Last();
+    }
+
+    [RelayCommand]
+    private void SelectCell(CellViewModel cell)
+    {
+        ActiveCell = cell;
+    }
+
+    [RelayCommand]
+    private async Task EvaluateSheetAsync()
+    {
+        if (SelectedSheet is null)
+        {
+            return;
+        }
+
+        await SelectedSheet.EvaluateAllAsync();
+    }
+
+    [RelayCommand]
+    private async Task EvaluateWorkbookAsync()
+    {
+        foreach (var sheet in Sheets)
+        {
+            await sheet.EvaluateAllAsync();
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        var definition = ToDefinition();
+        var fileName = Title.Replace(' ', '_') + ".aicalc";
+        var json = JsonSerializer.Serialize(definition, _serializerOptions);
+        await File.WriteAllTextAsync(fileName, json);
+        StatusMessage = $"Saved to {fileName}";
+    }
+
+    [RelayCommand]
+    private async Task LoadAsync()
+    {
+        var fileName = Title.Replace(' ', '_') + ".aicalc";
+        if (!File.Exists(fileName))
+        {
+            StatusMessage = $"File {fileName} not found";
+            return;
+        }
+
+        var json = await File.ReadAllTextAsync(fileName);
+        var definition = JsonSerializer.Deserialize<WorkbookDefinition>(json, _serializerOptions);
+        if (definition is null)
+        {
+            return;
+        }
+
+        ApplyDefinition(definition);
+        StatusMessage = $"Loaded {fileName}";
+    }
+
+    [RelayCommand]
+    private void ClearSelection()
+    {
+        foreach (var cell in Sheets.SelectMany(s => s.Cells))
+        {
+            cell.IsSelected = false;
+        }
+
+        ActiveCell = null;
+    }
+
+    public WorkbookDefinition ToDefinition()
+    {
+        var definition = new WorkbookDefinition
+        {
+            Title = Title,
+            Settings = Settings
+        };
+
+        foreach (var sheet in Sheets)
+        {
+            var sheetDef = new SheetDefinition
+            {
+                Name = sheet.Name,
+                RowCount = sheet.Rows.Count,
+                ColumnCount = sheet.ColumnCount
+            };
+
+            foreach (var cell in sheet.Cells)
+            {
+                if (cell.Value.ObjectType == CellObjectType.Empty && string.IsNullOrWhiteSpace(cell.Formula))
+                {
+                    continue;
+                }
+
+                sheetDef.Cells.Add(new CellDefinition
+                {
+                    Address = cell.Address.ToString(),
+                    Formula = cell.Formula,
+                    Value = cell.Value,
+                    AutomationMode = cell.AutomationMode,
+                    Notes = cell.Notes
+                });
+            }
+
+            definition.Sheets.Add(sheetDef);
+        }
+
+        return definition;
+    }
+
+    private void ApplyDefinition(WorkbookDefinition definition)
+    {
+        Sheets.Clear();
+        Title = definition.Title;
+        Settings = definition.Settings;
+
+        foreach (var sheet in definition.Sheets)
+        {
+            var sheetVm = new SheetViewModel(this, sheet.Name, sheet.RowCount, sheet.ColumnCount);
+            foreach (var cellDef in sheet.Cells)
+            {
+                if (!CellAddress.TryParse(cellDef.Address, sheet.Name, out var address))
+                {
+                    continue;
+                }
+
+                var cell = sheetVm.GetCell(address.Row, address.Column);
+                if (cell is null)
+                {
+                    continue;
+                }
+
+                cell.Formula = cellDef.Formula;
+                cell.AutomationMode = cellDef.AutomationMode;
+                cell.Notes = cellDef.Notes;
+                cell.Value = cellDef.Value;
+            }
+
+            Sheets.Add(sheetVm);
+        }
+
+        SelectedSheet = Sheets.FirstOrDefault();
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap a Uno Platform single-project shell for the AiCalc spreadsheet experience
- implement workbook, sheet, cell, and function infrastructure with MVVM view models and AI-aware function registry
- craft the main page UI with navigation, function explorer, spreadsheet grid, cell inspector, and workbook persistence commands, plus refreshed documentation

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2b5a529a883268466988c8d165bd2